### PR TITLE
fix: vorbis streams pass through transformer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Report incorrect or unexpected behaviour of any package
-title: '[BUG]: '
-labels: 'Bug 👾'
+title: 'fix: '
+labels: 'Meta: BugFix'
 assignees: ''
 
 ---
@@ -18,7 +18,7 @@ You likely won't receive any basic help here.
 
 
 **Include a reproducible code sample here, if possible:**
-```js
+```ts
 
 // Place your code here
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Request a feature for any package
-title: '[Request]: '
-labels: 'Addition 📤, Improvement 🎗️'
+title: 'feat: '
+labels: 'Meta: Feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question---general-support-request.md
+++ b/.github/ISSUE_TEMPLATE/question---general-support-request.md
@@ -1,8 +1,8 @@
 ---
 name: Question / General support request
 about: Ask for help in Discord instead - https://favware.tech/redirect/server
-title: '[Question]: '
-labels: 'Question 🤔'
+title: 'question: '
+labels: 'Type: Question'
 assignees: ''
 
 ---

--- a/packages/ytdl-prismplayer/src/index.ts
+++ b/packages/ytdl-prismplayer/src/index.ts
@@ -100,7 +100,7 @@ export const play = async (
       ...vorbisPrismArgs
     ],
   });
-  const opus = new prism.opus.Encoder({ frameSize: 960, channels: 2, rate: 4800 });
+  const opus = new prism.opus.Encoder({ frameSize: 960, channels: 2, rate: 48000 });
   const stream = transcoder.pipe(transcoder).pipe(opus);
 
   stream.on('close', () => {

--- a/packages/ytdl-prismplayer/src/index.ts
+++ b/packages/ytdl-prismplayer/src/index.ts
@@ -67,14 +67,22 @@ export const play = async (
   if (canDemux) ytdlOptions = { ...ytdlOptions, filter: shouldUseVorbis ? filterVorbis : filter };
   else if (Number(info.length_seconds) !== 0) ytdlOptions = { ...ytdlOptions, filter: shouldUseVorbis ? undefined : 'audioonly' };
   if (canDemux) {
-    let demuxer: prism.vorbis.WebmDemuxer | prism.opus.WebmDemuxer;
     if (shouldUseVorbis) {
-      demuxer = new prism.vorbis.WebmDemuxer();
-    } else {
-      demuxer = new prism.opus.WebmDemuxer();
-    }
+      const demuxer = new prism.vorbis.WebmDemuxer();
+      const transformer = new prism.opus.OggDemuxer();
 
-    return ytdl.downloadFromInfo(info, ytdlOptions).pipe(demuxer).on('end', () => demuxer.destroy());
+      return ytdl
+        .downloadFromInfo(info, ytdlOptions)
+        .pipe(demuxer)
+        .pipe(transformer)
+        .on('end', () => demuxer.destroy());
+    }
+    const demuxer = new prism.opus.WebmDemuxer();
+
+    return ytdl
+      .downloadFromInfo(info, ytdlOptions)
+      .pipe(demuxer)
+      .on('end', () => demuxer.destroy());
   }
 
   const vorbisPrismArgs = shouldUseVorbis ? [ '-b:a', '192k' ] : [];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This should fix vorbis based streams not working

**Monorepo Management**
- My changes affect:
  - [ ] converter
  - [ ] crypto
  - [ ] eslint-config
  - [ ] querystring
  - [ ] tslint-config
  - [ ] unescape
  - [ ] yamlreader
  - [x] ytdl-prismplayer
  - [ ] zalgo

**Status**
- [ ] Code changes have been tested against my own code, or there are no code changes

**Semantic versioning classification:**
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
