### PR TITLE
fix(zalgo): properly handle `up`/`middle`/`down` options

### DIFF
--- a/packages/zalgo/src/zalgo.ts
+++ b/packages/zalgo/src/zalgo.ts
@@ -37,9 +37,9 @@ export const zalgo = (
     let result = '';
     const types: string[] = [];
 
-    if (Reflect.has(options, 'up')) types.push('up');
-    if (Reflect.has(options, 'middle')) types.push('middle');
-    if (Reflect.has(options, 'down')) types.push('down');
+    if (options.up) types.push('up');
+    if (options.middle) types.push('middle');
+    if (options.down) types.push('down');
 
     for (let i = 0; i < splitTextLength; i++) {
       if (chars.pattern!.test(splitText[i])) continue;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes `zalgo()` so that the `up`/`middle`/`down` options work. Previous code was broken so that all 3 are always applied no matter what you pass in as options.

I took a look at existing unit tests for zalgo and see that there are technically tests for these options, but they do not effectively validate that the options are applied properly. I'm not sure how to improve the unit tests to actually validate correct behavior.

**Monorepo Management**

- My changes affect:
  - [ ] converter
  - [ ] crypto
  - [ ] querystring
  - [ ] yamlreader
  - [X] zalgo

**Status**

- [X] Code changes have been tested against my own code, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
